### PR TITLE
optout sigstore-maven from the binary artifacts policy

### DIFF
--- a/binary_artifacts.yaml
+++ b/binary_artifacts.yaml
@@ -1,6 +1,9 @@
 optConfig:
   optOutStrategy: true
   optOutRepos:
-  - rekor
   # rekor uses binary artifacts in tests/
+  - rekor
+  # sigstore-maven uses binary artifacts in .mvn and in src/test/
+  - sigstore-maven
+
 action: issue


### PR DESCRIPTION
#### Summary
- optout sigstore-maven from the binary artifacts policy

xref: https://github.com/sigstore/sigstore-maven/issues/2


cc @jvanzyl 

#### Ticket Link

n/a

#### Release Note

```release-note
NONE
```
