### PR TITLE
add exception for binary in protobuf-specs repo

### DIFF
--- a/binary_artifacts.yaml
+++ b/binary_artifacts.yaml
@@ -5,5 +5,7 @@ optConfig:
   - rekor
   # sigstore-maven uses binary artifacts in .mvn and in src/test/
   - sigstore-maven
+  # protobuf-specs uses binary artifacts java/gradle/wrapper/
+  - sigstore-maven
 
 action: issue


### PR DESCRIPTION
#### Summary
- add exception for binary in protobuf-specs repo
this is needed for the development and ci

Fix: https://github.com/sigstore/protobuf-specs/issues/23